### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Python Debugger extension for Visual Studio Code
 
-A [Visual Studio Code](https://code.visualstudio.com/) [extension](https://marketplace.visualstudio.com/VSCode) that supports Python debugging with debugpy. Python Debugger provides a seamless debugging experience by allowing you to set breakpoints, step through code, inspect variables, and perform other essential debugging tasks. The debugy extension offers debugging support for various types of Python applications including scripts, web applications, remote processes, and multi-threaded processes. 
+A [Visual Studio Code](https://code.visualstudio.com/) [extension](https://marketplace.visualstudio.com/VSCode) that supports Python debugging with debugpy. Python Debugger provides a seamless debugging experience by allowing you to set breakpoints, step through code, inspect variables, and perform other essential debugging tasks. The debugpy extension offers debugging support for various types of Python applications including scripts, web applications, remote processes, and multi-threaded processes. 
 
 Note: 
 - The Python extension offers the python debugger extension as an optional installation, including it during the setup process.
@@ -49,4 +49,4 @@ You can reference the table below to find the most recent Python Debugger extens
 
 
 ## Data and telemetry
-The Debubpy Extension for Visual Studio Code collects usage data and sends it to Microsoft to help improve our products and services. Read our [privacy statement](https://privacy.microsoft.com/privacystatement) to learn more. This extension respects the `telemetry.enableTelemetry` setting which you can learn more about at https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting.
+The Debugpy Extension for Visual Studio Code collects usage data and sends it to Microsoft to help improve our products and services. Read our [privacy statement](https://privacy.microsoft.com/privacystatement) to learn more. This extension respects the `telemetry.enableTelemetry` setting which you can learn more about at https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting.

--- a/package.json
+++ b/package.json
@@ -253,7 +253,7 @@
                         "properties": {
                             "args": {
                                 "default": [],
-                                "description": "Command line arguments passed to the program. For string type arguments, it will pass through the shell as is, and therefore all shell variable expansions will apply. But for the array type, tha values will be shell-escaped.",
+                                "description": "Command line arguments passed to the program. For string type arguments, it will pass through the shell as is, and therefore all shell variable expansions will apply. But for the array type, the values will be shell-escaped.",
                                 "items": {
                                     "type": "string"
                                 },
@@ -496,7 +496,7 @@
         "format-check": "prettier --check 'src/**/*.ts' 'build/**/*.yml' '.github/**/*.yml'",
         "format-fix": "prettier --write 'src/**/*.ts' 'build/**/*.yml' '.github/**/*.yml'",
         "test": "node ./out/test/runTest.js",
-        "vsce-package": "vsce package -o pyhton-debugger.vsix"
+        "vsce-package": "vsce package -o python-debugger.vsix"
     },
     "devDependencies": {
         "@types/chai": "^4.3.4",

--- a/src/extension/common/persistentState.ts
+++ b/src/extension/common/persistentState.ts
@@ -41,7 +41,7 @@ export class PersistentState<T> implements IPersistentState<T> {
                 await this.storage.update(this.key, newValue);
             }
             if (retryOnce && JSON.stringify(this.value) !== JSON.stringify(newValue)) {
-                // Due to a VSCode bug sometimes the changes are not reflected in the storage, atleast not immediately.
+                // Due to a VSCode bug sometimes the changes are not reflected in the storage, at least not immediately.
                 // It is noticed however that if we reset the storage first and then update it, it works.
                 // https://github.com/microsoft/vscode/issues/171827
                 traceVerbose('Storage update failed for key', this.key, ' retrying by resetting first');

--- a/src/extension/debugger/configuration/launch.json/updaterServiceHelper.ts
+++ b/src/extension/debugger/configuration/launch.json/updaterServiceHelper.ts
@@ -82,7 +82,7 @@ export class LaunchJsonUpdaterServiceHelper {
     ): string {
         const json = JSON.stringify(config);
         if (cursorPosition === 'AfterItem') {
-            // If we already have a comma immediatley before the cursor, then no need of adding a comma.
+            // If we already have a comma immediately before the cursor, then no need of adding a comma.
             return commaPosition === 'BeforeCursor' ? json : `,${json}`;
         }
         if (cursorPosition === 'BeforeItem') {

--- a/src/extension/debugger/helpers/protocolParser.ts
+++ b/src/extension/debugger/helpers/protocolParser.ts
@@ -82,9 +82,9 @@ export class ProtocolParser implements IProtocolParser {
                 break;
             }
             case 'response': {
-                const reponse = message as DebugProtocol.Response;
-                if (typeof reponse.command === 'string') {
-                    this.events.emit(`${message.type}_${reponse.command}`, reponse);
+                const response = message as DebugProtocol.Response;
+                if (typeof response.command === 'string') {
+                    this.events.emit(`${message.type}_${response.command}`, response);
                 }
                 break;
             }

--- a/src/extension/extensionInit.ts
+++ b/src/extension/extensionInit.ts
@@ -97,8 +97,8 @@ export async function registerDebugger(context: IExtensionContext): Promise<void
     );
 
     //PersistentStateFactory
-    const persistantState = new PersistentStateFactory(context.globalState, context.workspaceState);
-    persistantState.activate();
+    const persistentState = new PersistentStateFactory(context.globalState, context.workspaceState);
+    persistentState.activate();
 
     const attachProcessProvider = new AttachProcessProvider();
     const attachPicker = new AttachPicker(attachProcessProvider);
@@ -109,7 +109,7 @@ export async function registerDebugger(context: IExtensionContext): Promise<void
         }),
     );
 
-    const debugAdapterDescriptorFactory = new DebugAdapterDescriptorFactory(persistantState);
+    const debugAdapterDescriptorFactory = new DebugAdapterDescriptorFactory(persistentState);
     const debugSessionLoggingFactory = new DebugSessionLoggingFactory();
     const debuggerPromptFactory = new OutdatedDebuggerPromptFactory();
     context.subscriptions.push(debug.registerDebugAdapterTrackerFactory(DebuggerTypeName, debugSessionLoggingFactory));

--- a/src/extension/telemetry/index.ts
+++ b/src/extension/telemetry/index.ts
@@ -235,7 +235,7 @@ export function sendTelemetryWhenDone<P extends IEventNamePropertyMapping, E ext
             },
         );
     } else {
-        throw new Error('Method is neither a Promise nor a Theneable');
+        throw new Error('Method is neither a Promise nor a Thenable');
     }
 }
 
@@ -553,7 +553,7 @@ export interface IEventNamePropertyMapping {
          */
         watson: boolean;
         /**
-         * Whether degbugging `pyspark`.
+         * Whether debugging `pyspark`.
          *
          * @type {boolean}
          */
@@ -571,7 +571,7 @@ export interface IEventNamePropertyMapping {
          */
         scrapy: boolean;
         /**
-         * Whether degbugging with autoStartBrowser.
+         * Whether debugging with autoStartBrowser.
          *
          * @type {boolean}
          */

--- a/src/test/constants.ts
+++ b/src/test/constants.ts
@@ -10,12 +10,12 @@ export const TEST_TIMEOUT = 60_000;
 export const TEST_RETRYCOUNT = 3;
 export const IS_SMOKE_TEST = process.env.VSC_PYTHON_SMOKE_TEST === '1';
 export const IS_PERF_TEST = process.env.VSC_PYTHON_PERF_TEST === '1';
-export const IS_MULTI_ROOT_TEST = isMultitrootTest();
+export const IS_MULTI_ROOT_TEST = isMultiRootTest();
 
 // If running on CI server, then run debugger tests ONLY if the corresponding flag is enabled.
 export const TEST_DEBUGGER = IS_CI_SERVER ? IS_CI_SERVER_TEST_DEBUGGER : true;
 
-function isMultitrootTest() {
+function isMultiRootTest() {
     // No need to run smoke nor perf tests in a multi-root environment.
     if (IS_SMOKE_TEST || IS_PERF_TEST) {
         return false;

--- a/src/test/initialize.ts
+++ b/src/test/initialize.ts
@@ -59,7 +59,7 @@ export async function initializeTest(): Promise<any> {
 }
 export async function closeActiveWindows(): Promise<void> {
     await closeActiveNotebooks();
-    await closeWindowsInteral();
+    await closeWindowsInternal();
 }
 export async function closeActiveNotebooks(): Promise<void> {
     if (!vscode.env.appName.toLowerCase().includes('insiders') || !isANotebookOpen()) {
@@ -74,14 +74,14 @@ export async function closeActiveNotebooks(): Promise<void> {
     // Hence keep trying.
     for (let counter = 0; counter <= 5 && isANotebookOpen(); counter += 1) {
         await sleep(counter * 100);
-        await closeWindowsInteral();
+        await closeWindowsInternal();
     }
 }
 
-async function closeWindowsInteral() {
+async function closeWindowsInternal() {
     return new Promise<void>((resolve, reject) => {
         // Attempt to fix #1301.
-        // Lets not waste too much time.
+        // Let's not waste too much time.
         const timer = setTimeout(() => {
             reject(new Error("Command 'workbench.action.closeAllEditors' timed out"));
         }, 15000);

--- a/src/test/unittest/configuration/launch.json/updaterServerHelper.unit.test.ts
+++ b/src/test/unittest/configuration/launch.json/updaterServerHelper.unit.test.ts
@@ -390,7 +390,7 @@ suite('Debugging - launch.json Updater Service', () => {
         document.verifyAll();
         assert.strictEqual(debugConfigInserted, true);
     });
-    test('If cursor is at the begining of line 1 then there is no comma before cursor', async () => {
+    test('If cursor is at the beginning of line 1 then there is no comma before cursor', async () => {
         sandbox.restore();
         const document = typemoq.Mock.ofType<TextDocument>();
         const position = new Position(1, 0);

--- a/src/test/unittest/extensionInit.unit.test.ts
+++ b/src/test/unittest/extensionInit.unit.test.ts
@@ -33,7 +33,7 @@ suite('Debugging - register Debugging', () => {
     let loggingFactory: IDebugSessionLoggingFactory;
     let debuggerPromptFactory: IOutdatedDebuggerPromptFactory;
     let descriptorFactory: IDebugAdapterDescriptorFactory;
-    let persistantState: IPersistentStateFactory;
+    let persistentState: IPersistentStateFactory;
     let debugSessionTelemetry: vscode.DebugAdapterTrackerFactory;
     let completionProvider: LaunchJsonCompletionProvider;
 
@@ -48,9 +48,9 @@ suite('Debugging - register Debugging', () => {
         debuggerPromptFactory = new OutdatedDebuggerPromptFactory();
         debugSessionTelemetry = new DebugSessionTelemetry();
         completionProvider = new LaunchJsonCompletionProvider();
-        persistantState = new PersistentStateFactory(context.object.globalState, context.object.workspaceState);
+        persistentState = new PersistentStateFactory(context.object.globalState, context.object.workspaceState);
         registerCompletionItemProviderStub = sinon.stub(vscode.languages, 'registerCompletionItemProvider');
-        descriptorFactory = new DebugAdapterDescriptorFactory(persistantState);
+        descriptorFactory = new DebugAdapterDescriptorFactory(persistentState);
         context.setup((c) => c.subscriptions).returns(() => []);
     });
     teardown(() => {

--- a/src/test/unittest/utils.ts
+++ b/src/test/unittest/utils.ts
@@ -72,7 +72,7 @@ class DebugAdapterTracker {
     //  * onError(error: Error): void;
 
     private onDAPMessage(src: DAPSource, msg: DebugProtocol.ProtocolMessage) {
-        // Unomment this to see the DAP messages sent between VS Code and debugpy:
+        // Uncomment this to see the DAP messages sent between VS Code and debugpy:
         //console.log(`| DAP (${src === 'vscode' ? 'VS Code -> debugpy' : 'debugpy -> VS Code'})\n`, msg, '\n| DAP');
 
         // See: https://microsoft.github.io/debug-adapter-protocol/specification
@@ -194,7 +194,7 @@ class DebuggerSession {
         // Un-comment this to see the debug config used in this session:
         //console.log('|', session.config, '|');
         const started = await vscode.debug.startDebugging(this.wsRoot, this.config);
-        expect(started).to.be.equal(true, 'Debugger did not sart');
+        expect(started).to.be.equal(true, 'Debugger did not start');
         this.raw = debuggers.getSession(this.id);
         expect(this.raw).to.not.equal(undefined, 'session not set');
     }


### PR DESCRIPTION
I noticed "tha values will be shell-escaped" contained a typo while I was debugging Python for the first time, so I checked your project for typos and fixed the ones I was virtually certain about.

Some are in code, but I think I changed all affected occurrences.