### PR TITLE
Fix platform-specific error

### DIFF
--- a/build/azure-pipeline.pre-release.yml
+++ b/build/azure-pipeline.pre-release.yml
@@ -30,6 +30,8 @@ extends:
     l10nSourcePaths: ./src
     buildPlatforms:
       - name: Linux
+        vsceTarget: ''
+      - name: Linux
         packageArch: arm64
         vsceTarget: linux-arm64
       - name: Linux
@@ -47,9 +49,6 @@ extends:
       - name: Windows
         packageArch: arm
         vsceTarget: win32-arm64
-      - name: Windows
-        packageArch: ia32
-        vsceTarget: win32-ia32
       - name: Windows
         packageArch: x64
         vsceTarget: win32-x64

--- a/build/azure-pipeline.stable.yml
+++ b/build/azure-pipeline.stable.yml
@@ -27,6 +27,8 @@ extends:
     publishExtension: ${{ parameters.publishExtension }}
     buildPlatforms:
       - name: Linux
+        vsceTarget: ''
+      - name: Linux
         packageArch: arm64
         vsceTarget: linux-arm64
       - name: Linux
@@ -44,9 +46,6 @@ extends:
       - name: Windows
         packageArch: arm
         vsceTarget: win32-arm64
-      - name: Windows
-        packageArch: ia32
-        vsceTarget: win32-ia32
       - name: Windows
         packageArch: x64
         vsceTarget: win32-x64


### PR DESCRIPTION
- Fix error with win-32. (https://dev.azure.com/monacotools/Monaco/_build/results?buildId=263944&view=logs&j=793f6990-16b1-5115-c944-576b3bbf7e39&t=89578552-e55c-5f0f-ce69-3edb63ae6858)
-  Add default platform in order to ficx this. (Closed: https://github.com/microsoft/vscode-python-debugger/issues/230 )