### PR TITLE
Add variable presentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,6 +132,64 @@
                     "scope": "resource",
                     "type": "boolean"
                 },
+                "debugpy.debugVariablePresentation": {
+                    "default": {},
+                    "description": "%debugpy.debugVariablePresentation.description%",
+                    "scope": "resource",
+                    "type": "object",
+                    "properties": {
+                        "all": {
+                            "type": "string",
+                            "default": "group",
+                            "description" : "%debugpy.debugVariablePresentation.all.description%",
+                            "enum": [
+                                "inline",
+                                "group",
+                                "hide"
+                            ]
+                        },
+                        "class": {
+                            "type": "string",
+                            "default": "group",
+                            "description" : "%debugpy.debugVariablePresentation.class.description%",
+                            "enum": [
+                                "inline",
+                                "group",
+                                "hide"
+                            ]
+                        },
+                        "function": {
+                            "type": "string",
+                            "default": "group",
+                            "description" : "%debugpy.debugVariablePresentation.function.description%",
+                            "enum": [
+                                "inline",
+                                "group",
+                                "hide"
+                            ]
+                        },
+                        "protected": {
+                            "type": "string",
+                            "default": "group",
+                            "description" : "%debugpy.debugVariablePresentation.protected.description%",
+                            "enum": [
+                                "inline",
+                                "group",
+                                "hide"
+                            ]
+                        },
+                        "special": {
+                            "type": "string",
+                            "default": "group",
+                            "description" : "%debugpy.debugVariablePresentation.special.description%",
+                            "enum": [
+                                "inline",
+                                "group",
+                                "hide"
+                            ]
+                        }
+                    }
+                },
                 "debugpy.showPythonInlineValues": {
                     "default": false,
                     "description": "%debugpy.showPythonInlineValues.description%",
@@ -140,64 +198,6 @@
                     "tags": [
                         "experimental"
                     ]
-                },
-                "debugpy.variablePresentation": {
-                    "default": {},
-                    "description": "Allow the user to specify the preferred presentation of variables.",
-                    "scope": "resource",
-                    "type": "object",
-                    "properties": {
-                        "all":{
-                            "type": "string",
-                            "default": "group",
-                            "description" : "Set preferred presentation of variables for all instances.",
-                            "enum": [
-                                "inline",
-                                "group",
-                                "hide"
-                            ]
-                        },
-                        "class":{
-                            "type": "string",
-                            "default": "group",
-                            "description" : "Set Class presentation of variables.",
-                            "enum": [
-                                "inline",
-                                "group",
-                                "hide"
-                            ]
-                        },
-                        "function":{
-                            "type": "string",
-                            "default": "group",
-                            "description" : "Set Function preferred presentation of variables.",
-                            "enum": [
-                                "inline",
-                                "group",
-                                "hide"
-                            ]
-                        },
-                        "protected":{
-                            "type": "string",
-                            "default": "group",
-                            "description" : "Set Protected preferred presentation of variables.",
-                            "enum": [
-                                "inline",
-                                "group",
-                                "hide"
-                            ]
-                        },
-                        "special":{
-                            "type": "string",
-                            "default": "group",
-                            "description" : "Set Special preferred presentation of variables.",
-                            "enum": [
-                                "inline",
-                                "group",
-                                "hide"
-                            ]
-                        }
-                    }
                 }
             },
             "title": "Python Debugger",
@@ -228,6 +228,11 @@
                                     "port"
                                 ],
                                 "type": "object"
+                            },
+                            "consoleName": {
+                                "default": "Python Debug Console",
+                                "description": "Display name of the debug console or terminal",
+                                "type": "string"
                             },
                             "debugAdapterPath": {
                                 "description": "Path (fully qualified) to the python debug adapter executable.",
@@ -333,10 +338,61 @@
                                 "description": "Whether to enable Sub Process debugging",
                                 "type": "boolean"
                             },
-                            "consoleName": {
-                                "default": "Python Debug Console",
-                                "description": "Display name of the debug console or terminal",
-                                "type": "string"
+                            "variablePresentation": {
+                                "default": {},
+                                "description": "%debugpy.debugVariablePresentation.description%",
+                                "properties": {
+                                    "all": {
+                                        "type": "string",
+                                        "default": "group",
+                                        "description" : "%debugpy.debugVariablePresentation.all.description%",
+                                        "enum": [
+                                            "inline",
+                                            "group",
+                                            "hide"
+                                        ]
+                                    },
+                                    "class": {
+                                        "type": "string",
+                                        "default": "group",
+                                        "description" : "%debugpy.debugVariablePresentation.class.description%",
+                                        "enum": [
+                                            "inline",
+                                            "group",
+                                            "hide"
+                                        ]
+                                    },
+                                    "function": {
+                                        "type": "string",
+                                        "default": "group",
+                                        "description" : "%debugpy.debugVariablePresentation.function.description%",
+                                        "enum": [
+                                            "inline",
+                                            "group",
+                                            "hide"
+                                        ]
+                                    },
+                                    "protected": {
+                                        "type": "string",
+                                        "default": "group",
+                                        "description" : "%debugpy.debugVariablePresentation.protected.description%",
+                                        "enum": [
+                                            "inline",
+                                            "group",
+                                            "hide"
+                                        ]
+                                    },
+                                    "special": {
+                                        "type": "string",
+                                        "default": "group",
+                                        "description" : "%debugpy.debugVariablePresentation.special.description%",
+                                        "enum": [
+                                            "inline",
+                                            "group",
+                                            "hide"
+                                        ]
+                                    }
+                                }
                             }
                         }
                     },
@@ -400,6 +456,11 @@
                                 },
                                 "type": "object"
                             },
+                            "autoStartBrowser": {
+                                "default": false,
+                                "description": "Open external browser to launch the application",
+                                "type": "boolean"
+                            },
                             "console": {
                                 "default": "integratedTerminal",
                                 "description": "Where to launch the debug target: internal console, integrated terminal, or external terminal.",
@@ -409,6 +470,11 @@
                                     "internalConsole"
                                 ]
                             },
+                            "consoleName": {
+                                "default": "Python Debug Console",
+                                "description": "Display name of the debug console or terminal",
+                                "type": "string"
+                            },
                             "cwd": {
                                 "default": "${workspaceFolder}",
                                 "description": "Absolute path to the working directory of the program being debugged. Default is the root directory of the file (leave empty).",
@@ -417,11 +483,6 @@
                             "debugAdapterPath": {
                                 "description": "Path (fully qualified) to the Python debug adapter executable.",
                                 "type": "string"
-                            },
-                            "autoStartBrowser": {
-                                "default": false,
-                                "description": "Open external browser to launch the application",
-                                "type": "boolean"
                             },
                             "django": {
                                 "default": false,
@@ -445,6 +506,11 @@
                                 "default": false,
                                 "description": "Enable debugging of gevent monkey-patched code.",
                                 "type": "boolean"
+                            },
+                            "guiEventLoop": {
+                                "default": "matplotlib",
+                                "description": "The GUI event loop that's going to run. Possible values: \"matplotlib\", \"wx\", \"qt\", \"none\", or a custom function that'll be imported and run.",
+                                "type": "string"
                             },
                             "jinja": {
                                 "default": null,
@@ -558,15 +624,61 @@
                                 "description": "Running debug program under elevated permissions (on Unix).",
                                 "type": "boolean"
                             },
-                            "guiEventLoop": {
-                                "default": "matplotlib",
-                                "description": "The GUI event loop that's going to run. Possible values: \"matplotlib\", \"wx\", \"qt\", \"none\", or a custom function that'll be imported and run.",
-                                "type": "string"
-                            },
-                            "consoleName": {
-                                "default": "Python Debug Console",
-                                "description": "Display name of the debug console or terminal",
-                                "type": "string"
+                            "variablePresentation": {
+                                "default": {},
+                                "description": "%debugpy.debugVariablePresentation.description%",
+                                "properties": {
+                                    "all": {
+                                        "type": "string",
+                                        "default": "group",
+                                        "description" : "%debugpy.debugVariablePresentation.all.description%",
+                                        "enum": [
+                                            "inline",
+                                            "group",
+                                            "hide"
+                                        ]
+                                    },
+                                    "class": {
+                                        "type": "string",
+                                        "default": "group",
+                                        "description" : "%debugpy.debugVariablePresentation.class.description%",
+                                        "enum": [
+                                            "inline",
+                                            "group",
+                                            "hide"
+                                        ]
+                                    },
+                                    "function": {
+                                        "type": "string",
+                                        "default": "group",
+                                        "description" : "%debugpy.debugVariablePresentation.function.description%",
+                                        "enum": [
+                                            "inline",
+                                            "group",
+                                            "hide"
+                                        ]
+                                    },
+                                    "protected": {
+                                        "type": "string",
+                                        "default": "group",
+                                        "description" : "%debugpy.debugVariablePresentation.protected.description%",
+                                        "enum": [
+                                            "inline",
+                                            "group",
+                                            "hide"
+                                        ]
+                                    },
+                                    "special": {
+                                        "type": "string",
+                                        "default": "group",
+                                        "description" : "%debugpy.debugVariablePresentation.special.description%",
+                                        "enum": [
+                                            "inline",
+                                            "group",
+                                            "hide"
+                                        ]
+                                    }
+                                }
                             }
                         }
                     }

--- a/package.json
+++ b/package.json
@@ -140,6 +140,64 @@
                     "tags": [
                         "experimental"
                     ]
+                },
+                "debugpy.variablePresentation": {
+                    "default": {},
+                    "description": "Allow the user to specify the preferred presentation of variables.",
+                    "scope": "resource",
+                    "type": "object",
+                    "properties": {
+                        "all":{
+                            "type": "string",
+                            "default": "group",
+                            "description" : "Set preferred presentation of variables for all instances.",
+                            "enum": [
+                                "inline",
+                                "group",
+                                "hide"
+                            ]
+                        },
+                        "class":{
+                            "type": "string",
+                            "default": "group",
+                            "description" : "Set Class presentation of variables.",
+                            "enum": [
+                                "inline",
+                                "group",
+                                "hide"
+                            ]
+                        },
+                        "function":{
+                            "type": "string",
+                            "default": "group",
+                            "description" : "Set Function preferred presentation of variables.",
+                            "enum": [
+                                "inline",
+                                "group",
+                                "hide"
+                            ]
+                        },
+                        "protected":{
+                            "type": "string",
+                            "default": "group",
+                            "description" : "Set Protected preferred presentation of variables.",
+                            "enum": [
+                                "inline",
+                                "group",
+                                "hide"
+                            ]
+                        },
+                        "special":{
+                            "type": "string",
+                            "default": "group",
+                            "description" : "Set Special preferred presentation of variables.",
+                            "enum": [
+                                "inline",
+                                "group",
+                                "hide"
+                            ]
+                        }
+                    }
                 }
             },
             "title": "Python Debugger",

--- a/package.nls.json
+++ b/package.nls.json
@@ -5,5 +5,11 @@
     "debugpy.command.reportIssue.title": "Report Issue...",
     "debugpy.command.viewOutput.title": "Show Output",
     "debugpy.debugJustMyCode.description": "When debugging only step through user-written code. Disable this to allow stepping into library code.",
+    "debugpy.debugVariablePresentation.description": "Allow the user to specify the preferred presentation of variables.",
+    "debugpy.debugVariablePresentation.all.description": "Set preferred presentation of variables for all instances.",
+    "debugpy.debugVariablePresentation.class.description": "Set Class presentation of variables.",
+    "debugpy.debugVariablePresentation.function.description": "Set Function preferred presentation of variables.",
+    "debugpy.debugVariablePresentation.protected.description": "Set Protected preferred presentation of variables.",
+    "debugpy.debugVariablePresentation.special.description": "Set Special preferred presentation of variables.",
     "debugpy.showPythonInlineValues.description": "Whether to display inline values in the editor while debugging."
 }

--- a/src/extension/debugger/configuration/resolvers/attach.ts
+++ b/src/extension/debugger/configuration/resolvers/attach.ts
@@ -50,6 +50,12 @@ export class AttachConfigurationResolver extends BaseConfigurationResolver<Attac
                 true,
             );
         }
+        if (debugConfiguration.variablePresentation == undefined) {
+            debugConfiguration.variablePresentation = getConfiguration('debugpy', workspaceFolder).get<object>(
+                'variablePresentation',
+                {},
+            );
+        }
         debugConfiguration.showReturnValue = debugConfiguration.showReturnValue !== false;
         // Pass workspace folder so we can get this when we get debug events firing.
         debugConfiguration.workspaceFolder = workspaceFolder ? workspaceFolder.fsPath : undefined;

--- a/src/extension/debugger/configuration/resolvers/attach.ts
+++ b/src/extension/debugger/configuration/resolvers/attach.ts
@@ -50,7 +50,7 @@ export class AttachConfigurationResolver extends BaseConfigurationResolver<Attac
                 true,
             );
         }
-        if (debugConfiguration.variablePresentation == undefined) {
+        if (debugConfiguration.variablePresentation === undefined) {
             debugConfiguration.variablePresentation = getConfiguration('debugpy', workspaceFolder).get<object>(
                 'debugVariablePresentation',
                 {},

--- a/src/extension/debugger/configuration/resolvers/attach.ts
+++ b/src/extension/debugger/configuration/resolvers/attach.ts
@@ -52,7 +52,7 @@ export class AttachConfigurationResolver extends BaseConfigurationResolver<Attac
         }
         if (debugConfiguration.variablePresentation == undefined) {
             debugConfiguration.variablePresentation = getConfiguration('debugpy', workspaceFolder).get<object>(
-                'variablePresentation',
+                'debugVariablePresentation',
                 {},
             );
         }

--- a/src/extension/debugger/configuration/resolvers/launch.ts
+++ b/src/extension/debugger/configuration/resolvers/launch.ts
@@ -116,7 +116,7 @@ export class LaunchConfigurationResolver extends BaseConfigurationResolver<Launc
         }
         if (debugConfiguration.variablePresentation == undefined) {
             debugConfiguration.variablePresentation = getConfiguration('debugpy', workspaceFolder).get<object>(
-                'variablePresentation',
+                'debugVariablePresentation',
                 {},
             );
         }

--- a/src/extension/debugger/configuration/resolvers/launch.ts
+++ b/src/extension/debugger/configuration/resolvers/launch.ts
@@ -114,6 +114,12 @@ export class LaunchConfigurationResolver extends BaseConfigurationResolver<Launc
                 true,
             );
         }
+        if (debugConfiguration.variablePresentation == undefined) {
+            debugConfiguration.variablePresentation = getConfiguration('debugpy', workspaceFolder).get<object>(
+                'variablePresentation',
+                {},
+            );
+        }
         // Pass workspace folder so we can get this when we get debug events firing.
         debugConfiguration.workspaceFolder = workspaceFolder ? workspaceFolder.fsPath : undefined;
         const debugOptions = debugConfiguration.debugOptions!;

--- a/src/extension/debugger/configuration/resolvers/launch.ts
+++ b/src/extension/debugger/configuration/resolvers/launch.ts
@@ -114,7 +114,7 @@ export class LaunchConfigurationResolver extends BaseConfigurationResolver<Launc
                 true,
             );
         }
-        if (debugConfiguration.variablePresentation == undefined) {
+        if (debugConfiguration.variablePresentation === undefined) {
             debugConfiguration.variablePresentation = getConfiguration('debugpy', workspaceFolder).get<object>(
                 'debugVariablePresentation',
                 {},

--- a/src/test/unittest/configuration/resolvers/attach.unit.test.ts
+++ b/src/test/unittest/configuration/resolvers/attach.unit.test.ts
@@ -578,28 +578,28 @@ getInfoPerOS().forEach(([osName, osType, path]) => {
             {
                 variablePresentation: {},
                 variablePresentationSetting: {
-                    "class": "inline"
+                    class: 'inline',
                 },
                 expectedResult: {},
             },
             {
                 variablePresentation: {
-                    "class": "inline"
+                    class: 'inline',
                 },
                 variablePresentationSetting: {
-                    "class": "hide"
+                    class: 'hide',
                 },
                 expectedResult: {
-                    "class": "inline"
+                    class: 'inline',
                 },
             },
             {
                 variablePresentation: undefined,
                 variablePresentationSetting: {
-                    "class": "inline"
+                    class: 'inline',
                 },
                 expectedResult: {
-                    "class": "inline"
+                    class: 'inline',
                 },
             },
         ];
@@ -623,8 +623,9 @@ getInfoPerOS().forEach(([osName, osType, path]) => {
                     debugOptions,
                     variablePresentation: testParams.variablePresentation,
                 });
-                expect(debugConfig).to.have.property('variablePresentation').that.deep.equals(testParams.expectedResult); // Corrected to use deep.equals
-
+                expect(debugConfig)
+                    .to.have.property('variablePresentation')
+                    .that.deep.equals(testParams.expectedResult); // Corrected to use deep.equals
             });
         });
 

--- a/src/test/unittest/configuration/resolvers/launch.unit.test.ts
+++ b/src/test/unittest/configuration/resolvers/launch.unit.test.ts
@@ -815,28 +815,28 @@ getInfoPerOS().forEach(([osName, osType, path]) => {
             {
                 variablePresentation: {},
                 variablePresentationSetting: {
-                    "class": "inline"
+                    class: 'inline',
                 },
                 expectedResult: {},
             },
             {
                 variablePresentation: {
-                    "class": "inline"
+                    class: 'inline',
                 },
                 variablePresentationSetting: {
-                    "class": "hide"
+                    class: 'hide',
                 },
                 expectedResult: {
-                    "class": "inline"
+                    class: 'inline',
                 },
             },
             {
                 variablePresentation: undefined,
                 variablePresentationSetting: {
-                    "class": "inline"
+                    class: 'inline',
                 },
                 expectedResult: {
-                    "class": "inline"
+                    class: 'inline',
                 },
             },
         ];
@@ -854,8 +854,9 @@ getInfoPerOS().forEach(([osName, osType, path]) => {
                     ...launch,
                     variablePresentation: testParams.variablePresentation,
                 });
-                expect(debugConfig).to.have.property('variablePresentation').that.deep.equals(testParams.expectedResult); // Corrected to use deep.equals
-
+                expect(debugConfig)
+                    .to.have.property('variablePresentation')
+                    .that.deep.equals(testParams.expectedResult); // Corrected to use deep.equals
             });
         });
 


### PR DESCRIPTION
Closed: https://github.com/microsoft/vscode-python-debugger/issues/165
- Add debugVariablePresentation as a setting so the user can set this value globally.
- Add variablePresentation in debug config so the user can set it in the launch.json.
- Update the config order alphabetically.
- Create test.