### PR TITLE
Make "args": "${command:pickArgs}" as default debug configuration

### DIFF
--- a/src/extension/debugger/configuration/providers/fileLaunchWithArgs.ts
+++ b/src/extension/debugger/configuration/providers/fileLaunchWithArgs.ts
@@ -21,7 +21,7 @@ export async function buildFileWithArgsLaunchDebugConfiguration(
         request: 'launch',
         program: '${file}',
         console: 'integratedTerminal',
-        args: ['${command:pickArgs}'],
+        args: '${command:pickArgs}',
     };
     sendTelemetryEvent(EventName.DEBUGGER_CONFIGURATION_PROMPTS, undefined, {
         configurationType: DebugConfigurationType.launchFileWithArgs,

--- a/src/test/unittest/configuration/providers/fileLaunchWithArgs.unit.test.ts
+++ b/src/test/unittest/configuration/providers/fileLaunchWithArgs.unit.test.ts
@@ -28,7 +28,7 @@ suite('Debugging - Configuration Provider File with Arguments', () => {
             request: 'launch',
             program: '${file}',
             console: 'integratedTerminal',
-            args: ['${command:pickArgs}'],
+            args: '${command:pickArgs}',
         };
 
         expect(state.config).to.be.deep.equal(config);


### PR DESCRIPTION
This PR is related to these issues:
https://github.com/microsoft/vscode/issues/225834
https://github.com/microsoft/vscode/issues/232560
https://github.com/microsoft/vscode-python-debugger/issues/233
https://github.com/microsoft/vscode-python-debugger/issues/465
https://github.com/microsoft/vscode-python-debugger/issues/497

I searched `repo:microsoft/vscode-python-debugger command:pickArgs` filtered by code, and find four snippet in thee files.

https://github.com/microsoft/vscode-python-debugger/blob/1b6ac0d2836a6288131de032e68d56f4770640e0/src/extension/debugger/configuration/providers/fileLaunchWithArgs.ts#L21-L27

https://github.com/microsoft/vscode-python-debugger/blob/1b6ac0d2836a6288131de032e68d56f4770640e0/src/test/unittest/configuration/providers/fileLaunchWithArgs.unit.test.ts#L28-L34

https://github.com/microsoft/vscode-python-debugger/blob/1b6ac0d2836a6288131de032e68d56f4770640e0/package.json#L286-L306

In lines 286 to 306 of `package.json`, it shows three usages of the `args` parameter. The first is that the value of the `args` parameter is "${command:pickArgs}", the second is to provide an array, and the third is to provide a string.

In the [vscode documentation](https://code.visualstudio.com/docs/python/debugging#:~:text=Note%3A%20There%20is%20a%20difference), it is also mentioned:

<blockquote><p><strong>Note</strong>: There is a difference in how <code>"${command:pickArgs}"</code> and <code>["${command:pickArgs}"]</code> are parsed, with specific notice to the usage of <code>[]</code>. As an array, all arguments are passed as a single string, without brackets each argument is passed as its own string.</p></blockquote>

Therefore, I think the two files `fileLaunchWithArgs.ts` and `fileLaunchWithArgs.unit.test.ts` are the key factors affecting this problem. Then I delete the [ ] in these two code snippets.

---

When I wrote this PR, I checked the file modification history and found that the modification in PR #385 added [ ], but this was completely wrong (refer to the discussion of issue #497), and was not the correct way to solve issue #233 (PR #499 solved the problem), and led to a series of issues listed at the beginning.

Just consider this PR to have coincidentally performed a "revert" operation.