### PR TITLE
Support the clientOS property in VS code

### DIFF
--- a/package.json
+++ b/package.json
@@ -278,6 +278,15 @@
                                 "default": "Python Debug Console",
                                 "description": "Display name of the debug console or terminal",
                                 "type": "string"
+                            },
+                            "clientOS": {
+                                "default": null,
+                                "description": "OS that VS code is using.",
+                                "enum": [
+                                    "windows",
+                                    null,
+                                    "unix"
+                                ]
                             }
                         }
                     },
@@ -508,6 +517,15 @@
                                 "default": "Python Debug Console",
                                 "description": "Display name of the debug console or terminal",
                                 "type": "string"
+                            },
+                            "clientOS": {
+                                "default": null,
+                                "description": "OS that VS code is using.",
+                                "enum": [
+                                    "windows",
+                                    null,
+                                    "unix"
+                                ]
                             }
                         }
                     }

--- a/src/extension/debugger/configuration/resolvers/attach.ts
+++ b/src/extension/debugger/configuration/resolvers/attach.ts
@@ -27,7 +27,7 @@ export class AttachConfigurationResolver extends BaseConfigurationResolver<Attac
                 (item, pos) => dbgConfig.debugOptions!.indexOf(item) === pos,
             );
         }
-        if (debugConfiguration.clientOS === undefined) {
+        if (!debugConfiguration.clientOS) {
             debugConfiguration.clientOS = getOSType() === OSType.Windows ? 'windows' : 'unix';
         }
         return debugConfiguration;
@@ -80,7 +80,7 @@ export class AttachConfigurationResolver extends BaseConfigurationResolver<Attac
         if (getOSType() === OSType.Windows && isLocalHost) {
             AttachConfigurationResolver.debugOption(debugOptions, DebugOptions.FixFilePathCase);
         }
-        if (debugConfiguration.clientOS === undefined) {
+        if (!debugConfiguration.clientOS) {
             debugConfiguration.clientOS = getOSType() === OSType.Windows ? 'windows' : 'unix';
         }
         if (debugConfiguration.showReturnValue) {

--- a/src/extension/debugger/configuration/resolvers/base.ts
+++ b/src/extension/debugger/configuration/resolvers/base.ts
@@ -39,7 +39,7 @@ export abstract class BaseConfigurationResolver<T extends DebugConfiguration>
         debugConfiguration: DebugConfiguration,
         _token?: CancellationToken,
     ): Promise<T | undefined> {
-        if (debugConfiguration.clientOS === undefined) {
+        if (!debugConfiguration.clientOS) {
             debugConfiguration.clientOS = getOSType() === OSType.Windows ? 'windows' : 'unix';
         }
         if (debugConfiguration.consoleName) {

--- a/src/extension/debugger/configuration/resolvers/launch.ts
+++ b/src/extension/debugger/configuration/resolvers/launch.ts
@@ -37,7 +37,7 @@ export class LaunchConfigurationResolver extends BaseConfigurationResolver<Launc
 
         const workspaceFolder = LaunchConfigurationResolver.getWorkspaceFolder(folder);
         await this.resolveAndUpdatePaths(workspaceFolder, debugConfiguration);
-        if (debugConfiguration.clientOS === undefined) {
+        if (!debugConfiguration.clientOS) {
             debugConfiguration.clientOS = getOSType() === OSType.Windows ? 'windows' : 'unix';
         }
         if (debugConfiguration.consoleName) {


### PR DESCRIPTION
As seen in this [issue](https://github.com/microsoft/debugpy/issues/1301), 'clientOS' is not an allowed entry in a launch.json. This PR adds the entry.