### PR TITLE
disable extra output for no config debug

### DIFF
--- a/src/extension/noConfigDebugInit.ts
+++ b/src/extension/noConfigDebugInit.ts
@@ -46,6 +46,9 @@ export async function registerNoConfigDebug(
     }
     const tempFilePath = path.join(tempDirPath, 'debuggerAdapterEndpoint.txt');
 
+    // Add env var for PYDEVD_DISABLE_FILE_VALIDATION to disable extra output in terminal when starting the debug session.
+    collection.replace('PYDEVD_DISABLE_FILE_VALIDATION', '1');
+
     // Add env vars for DEBUGPY_ADAPTER_ENDPOINTS, BUNDLED_DEBUGPY_PATH, and PATH
     collection.replace('DEBUGPY_ADAPTER_ENDPOINTS', tempFilePath);
 

--- a/src/test/unittest/noConfigDebugInit.unit.test.ts
+++ b/src/test/unittest/noConfigDebugInit.unit.test.ts
@@ -62,6 +62,8 @@ suite('setup for no-config debug scenario', function () {
                     assert(value.includes('noConfigDebugAdapterEndpoints-1234567899'));
                 } else if (key === BUNDLED_DEBUGPY_PATH) {
                     assert(value === bundledDebugPath);
+                } else if (key === 'PYDEVD_DISABLE_FILE_VALIDATION') {
+                    assert(value === '1');
                 }
             })
             .returns(envVarCollectionReplaceStub);
@@ -82,7 +84,7 @@ suite('setup for no-config debug scenario', function () {
         await registerNoConfigDebug(context.object.environmentVariableCollection, context.object.extensionPath);
 
         // assert that functions called right number of times
-        sinon.assert.calledTwice(envVarCollectionReplaceStub);
+        sinon.assert.calledThrice(envVarCollectionReplaceStub);
         sinon.assert.calledOnce(envVarCollectionAppendStub);
     });
 


### PR DESCRIPTION
sets env var 'PYDEVD_DISABLE_FILE_VALIDATION' as to not have extra output printed when debugpy is called