### PR TITLE
Allow autoReload in attach configurations

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,6 +149,43 @@
                 "configurationAttributes": {
                     "attach": {
                         "properties": {
+                            "autoReload": {
+                                "default": {},
+                                "description": "Configures automatic reload of code on edit.",
+                                "properties": {
+                                    "enable": {
+                                        "default": false,
+                                        "description": "Automatically reload code on edit.",
+                                        "type": "boolean"
+                                    },
+                                    "exclude": {
+                                        "default": [
+                                            "**/.git/**",
+                                            "**/.metadata/**",
+                                            "**/__pycache__/**",
+                                            "**/node_modules/**",
+                                            "**/site-packages/**"
+                                        ],
+                                        "description": "Glob patterns of paths to exclude from auto reload.",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "include": {
+                                        "default": [
+                                            "**/*.py",
+                                            "**/*.pyw"
+                                        ],
+                                        "description": "Glob patterns of paths to include in auto reload.",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    }
+                                },
+                                "type": "object"
+                            },
                             "connect": {
                                 "label": "Attach by connecting to debugpy over a socket.",
                                 "properties": {


### PR DESCRIPTION
See this discussion:
https://github.com/microsoft/debugpy/discussions/1875

Not sure why autoReload wasn't in the attach configuration too, unless I'm missing something. 