### PR TITLE
Fix `TypeError` from trying to read directory

### DIFF
--- a/src/extension/noConfigDebugInit.ts
+++ b/src/extension/noConfigDebugInit.ts
@@ -87,7 +87,7 @@ export async function registerNoConfigDebug(
     );
 
     // create file system watcher for the debuggerAdapterEndpointFolder for when the communication port is written
-    const fileSystemWatcher = createFileSystemWatcher(new RelativePattern(tempDirPath, '**/*'));
+    const fileSystemWatcher = createFileSystemWatcher(new RelativePattern(tempDirPath, '**/*.txt'));
     const fileCreationEvent = fileSystemWatcher.onDidCreate(async (uri) => {
         sendTelemetryEvent(EventName.DEBUG_SESSION_START, undefined, {
             trigger: 'noConfig' as TriggerType,
@@ -95,13 +95,13 @@ export async function registerNoConfigDebug(
 
         const filePath = uri.fsPath;
         fs.readFile(filePath, (err, data) => {
-            const dataParse = data.toString();
             if (err) {
                 traceError(`Error reading debuggerAdapterEndpoint.txt file: ${err}`);
                 return;
             }
             try {
                 // parse the client port
+                const dataParse = data.toString();
                 const jsonData = JSON.parse(dataParse);
                 const clientPort = jsonData.client?.port;
                 traceVerbose(`Parsed client port: ${clientPort}`);

--- a/src/test/unittest/noConfigDebugInit.unit.test.ts
+++ b/src/test/unittest/noConfigDebugInit.unit.test.ts
@@ -99,7 +99,7 @@ suite('setup for no-config debug scenario', function () {
 
         // Assert
         sinon.assert.calledOnce(createFileSystemWatcherFunct);
-        const expectedPattern = new RelativePattern(path.join(os.tmpdir(), '.noConfigDebugAdapterEndpoints'), '**/*');
+        const expectedPattern = new RelativePattern(path.join(os.tmpdir(), '.noConfigDebugAdapterEndpoints'), '**/*.txt');
         sinon.assert.calledWith(createFileSystemWatcherFunct, expectedPattern);
     });
 

--- a/src/test/unittest/noConfigDebugInit.unit.test.ts
+++ b/src/test/unittest/noConfigDebugInit.unit.test.ts
@@ -99,7 +99,10 @@ suite('setup for no-config debug scenario', function () {
 
         // Assert
         sinon.assert.calledOnce(createFileSystemWatcherFunct);
-        const expectedPattern = new RelativePattern(path.join(os.tmpdir(), '.noConfigDebugAdapterEndpoints'), '**/*.txt');
+        const expectedPattern = new RelativePattern(
+            path.join(os.tmpdir(), '.noConfigDebugAdapterEndpoints'),
+            '**/*.txt',
+        );
         sinon.assert.calledWith(createFileSystemWatcherFunct, expectedPattern);
     });
 


### PR DESCRIPTION
Fixes #691

The file watcher will trigger on the temp directory (when it is first created), throwing an error.