### PR TITLE
update so deprecation shown for <3.9 not <=3.9

### DIFF
--- a/src/extension/debugger/adapter/factory.ts
+++ b/src/extension/debugger/adapter/factory.ts
@@ -181,7 +181,7 @@ export class DebugAdapterDescriptorFactory implements IDebugAdapterDescriptorFac
         if (interpreter) {
             if (
                 (interpreter.version?.major ?? 0) < 3 ||
-                ((interpreter.version?.major ?? 0) <= 3 && (interpreter.version?.minor ?? 0) <= 9)
+                ((interpreter.version?.major ?? 0) <= 3 && (interpreter.version?.minor ?? 0) < 9)
             ) {
                 this.showDeprecatedPythonMessage();
             }


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-python-debugger/issues/712