### PR TITLE
Add debugpy versions for Python 3.13 + 3.14

### DIFF
--- a/debugpy_info.json
+++ b/debugpy_info.json
@@ -1,61 +1,61 @@
 {
     "macOS": [
         {
-            "url": "https://files.pythonhosted.org/packages/bf/98/d57054371887f37d3c959a7a8dc3c76b763acb65f5e78d849d7db7cadc5b/debugpy-1.8.19-cp310-cp310-macosx_15_0_x86_64.whl",
-            "hash": {
-                "sha256": "fce6da15d73be5935b4438435c53adb512326a3e11e4f90793ea87cd9f018254"
-            }
-        },
-        {
-            "url": "https://files.pythonhosted.org/packages/80/e2/48531a609b5a2aa94c6b6853afdfec8da05630ab9aaa96f1349e772119e9/debugpy-1.8.19-cp311-cp311-macosx_15_0_universal2.whl",
-            "hash": {
-                "sha256": "c5dcfa21de1f735a4f7ced4556339a109aa0f618d366ede9da0a3600f2516d8b"
-            }
-        },
-        {
             "url": "https://files.pythonhosted.org/packages/4a/15/d762e5263d9e25b763b78be72dc084c7a32113a0bac119e2f7acae7700ed/debugpy-1.8.19-cp312-cp312-macosx_15_0_universal2.whl",
             "hash": {
                 "sha256": "bccb1540a49cde77edc7ce7d9d075c1dbeb2414751bc0048c7a11e1b597a4c2e"
+            }
+        },
+        {
+            "url": "https://files.pythonhosted.org/packages/71/3d/388035a31a59c26f1ecc8d86af607d0c42e20ef80074147cd07b180c4349/debugpy-1.8.19-cp313-cp313-macosx_15_0_universal2.whl",
+            "hash": {
+                "sha256": "91e35db2672a0abaf325f4868fcac9c1674a0d9ad9bb8a8c849c03a5ebba3e6d"
+            }
+        },
+        {
+            "url": "https://files.pythonhosted.org/packages/f6/b9/cbec520c3a00508327476c7fce26fbafef98f412707e511eb9d19a2ef467/debugpy-1.8.19-cp314-cp314-macosx_15_0_universal2.whl",
+            "hash": {
+                "sha256": "1e8c4d1bd230067bf1bbcdbd6032e5a57068638eb28b9153d008ecde288152af"
             }
         }
     ],
     "win64": [
         {
-            "url": "https://files.pythonhosted.org/packages/a6/36/7f9053c4c549160c87ae7e43800138f2695578c8b65947114c97250983b6/debugpy-1.8.19-cp310-cp310-win_amd64.whl",
-            "hash": {
-                "sha256": "b7dd275cf2c99e53adb9654f5ae015f70415bbe2bacbe24cfee30d54b6aa03c5"
-            }
-        },
-        {
-            "url": "https://files.pythonhosted.org/packages/f2/a8/aaac7ff12ddf5d68a39e13a423a8490426f5f661384f5ad8d9062761bd8e/debugpy-1.8.19-cp311-cp311-win_amd64.whl",
-            "hash": {
-                "sha256": "14035cbdbb1fe4b642babcdcb5935c2da3b1067ac211c5c5a8fdc0bb31adbcaa"
-            }
-        },
-        {
             "url": "https://files.pythonhosted.org/packages/d8/3a/d3d8b48fec96e3d824e404bf428276fb8419dfa766f78f10b08da1cb2986/debugpy-1.8.19-cp312-cp312-win_amd64.whl",
             "hash": {
                 "sha256": "66e3d2fd8f2035a8f111eb127fa508469dfa40928a89b460b41fd988684dc83d"
+            }
+        },
+        {
+            "url": "https://files.pythonhosted.org/packages/fb/4e/931480b9552c7d0feebe40c73725dd7703dcc578ba9efc14fe0e6d31cfd1/debugpy-1.8.19-cp313-cp313-win_amd64.whl",
+            "hash": {
+                "sha256": "c30639998a9f9cd9699b4b621942c0179a6527f083c72351f95c6ab1728d5b73"
+            }
+        },
+        {
+            "url": "https://files.pythonhosted.org/packages/17/b8/bfdc30b6e94f1eff09f2dc9cc1f9cd1c6cde3d996bcbd36ce2d9a4956e99/debugpy-1.8.19-cp314-cp314-win_amd64.whl",
+            "hash": {
+                "sha256": "8e19a725f5d486f20e53a1dde2ab8bb2c9607c40c00a42ab646def962b41125f"
             }
         }
     ],
     "linux": [
         {
-            "url": "https://files.pythonhosted.org/packages/ee/dd/c517b9aa3500157a30e4f4c4f5149f880026bd039d2b940acd2383a85d8e/debugpy-1.8.19-cp310-cp310-manylinux_2_34_x86_64.whl",
-            "hash": {
-                "sha256": "e24b1652a1df1ab04d81e7ead446a91c226de704ff5dde6bd0a0dbaab07aa3f2"
-            }
-        },
-        {
-            "url": "https://files.pythonhosted.org/packages/1b/d4/97775c01d56071969f57d93928899e5616a4cfbbf4c8cc75390d3a51c4a4/debugpy-1.8.19-cp311-cp311-manylinux_2_34_x86_64.whl",
-            "hash": {
-                "sha256": "806d6800246244004625d5222d7765874ab2d22f3ba5f615416cf1342d61c488"
-            }
-        },
-        {
             "url": "https://files.pythonhosted.org/packages/a7/88/f7d25c68b18873b7c53d7c156ca7a7ffd8e77073aa0eac170a9b679cf786/debugpy-1.8.19-cp312-cp312-manylinux_2_34_x86_64.whl",
             "hash": {
                 "sha256": "e9c68d9a382ec754dc05ed1d1b4ed5bd824b9f7c1a8cd1083adb84b3c93501de"
+            }
+        },
+        {
+            "url": "https://files.pythonhosted.org/packages/4a/19/c93a0772d0962294f083dbdb113af1a7427bb632d36e5314297068f55db7/debugpy-1.8.19-cp313-cp313-manylinux_2_34_x86_64.whl",
+            "hash": {
+                "sha256": "85016a73ab84dea1c1f1dcd88ec692993bcbe4532d1b49ecb5f3c688ae50c606"
+            }
+        },
+        {
+            "url": "https://files.pythonhosted.org/packages/88/5e/cf4e4dc712a141e10d58405c58c8268554aec3c35c09cdcda7535ff13f76/debugpy-1.8.19-cp314-cp314-manylinux_2_34_x86_64.whl",
+            "hash": {
+                "sha256": "d40c016c1f538dbf1762936e3aeb43a89b965069d9f60f9e39d35d9d25e6b809"
             }
         }
     ],

--- a/noxfile.py
+++ b/noxfile.py
@@ -154,7 +154,7 @@ def create_debugpy_json(session: nox.Session):
     for p, id in platforms:
         # we typically have the latest 3 versions of debugpy compiled bits
         downloads = []
-        for cp in ["cp310", "cp311", "cp312"]:
+        for cp in ["cp312", "cp313", "cp314"]:
             data = _get_debugpy_info("latest", id, cp)
             if not any(d["url"] == data["url"] for d in downloads):
                 downloads.append(data)


### PR DESCRIPTION
Debugpy has binaries for Python 3.13 and 3.14. Update the nox file to pull them in.