### PR TITLE
no config debug: Add `debugpy.sh`

### DIFF
--- a/bundled/scripts/noConfigScripts/debugpy.sh
+++ b/bundled/scripts/noConfigScripts/debugpy.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+# Bash script
+export DEBUGPY_ADAPTER_ENDPOINTS=$VSCODE_DEBUGPY_ADAPTER_ENDPOINTS
+python3 $BUNDLED_DEBUGPY_PATH --listen 0 --wait-for-client $@

--- a/bundled/scripts/noConfigScripts/debugpy.sh
+++ b/bundled/scripts/noConfigScripts/debugpy.sh
@@ -1,4 +1,4 @@
 #! /bin/bash
-# Bash script
+# Bash script - a copy of `debugpy` for cases where the user has a conflicting `debugpy` in their `PATH`.
 export DEBUGPY_ADAPTER_ENDPOINTS=$VSCODE_DEBUGPY_ADAPTER_ENDPOINTS
 python3 $BUNDLED_DEBUGPY_PATH --listen 0 --wait-for-client $@


### PR DESCRIPTION
It seemed non trivial to do something other than just copying the existing `debugpy` script, so that's what I opted for.

Close https://github.com/microsoft/vscode-python-debugger/issues/651.
