### PR TITLE
no config debug: Fix env var name in test

### DIFF
--- a/src/test/unittest/noConfigDebugInit.unit.test.ts
+++ b/src/test/unittest/noConfigDebugInit.unit.test.ts
@@ -19,7 +19,7 @@ suite('setup for no-config debug scenario', function () {
     let context: TypeMoq.IMock<IExtensionContext>;
     let noConfigScriptsDir: string;
     let bundledDebugPath: string;
-    let DEBUGPY_ADAPTER_ENDPOINTS = 'DEBUGPY_ADAPTER_ENDPOINTS';
+    let DEBUGPY_ADAPTER_ENDPOINTS = 'VSCODE_DEBUGPY_ADAPTER_ENDPOINTS';
     let BUNDLED_DEBUGPY_PATH = 'BUNDLED_DEBUGPY_PATH';
     let workspaceUriStub: sinon.SinonStub;
 
@@ -49,7 +49,7 @@ suite('setup for no-config debug scenario', function () {
         workspaceUriStub.restore();
     });
 
-    test('should add environment variables for DEBUGPY_ADAPTER_ENDPOINTS, BUNDLED_DEBUGPY_PATH, and PATH', async () => {
+    test('should add environment variables for VSCODE_DEBUGPY_ADAPTER_ENDPOINTS, BUNDLED_DEBUGPY_PATH, and PATH', async () => {
         const environmentVariableCollectionMock = TypeMoq.Mock.ofType<any>();
         envVarCollectionReplaceStub = sinon.stub();
         envVarCollectionAppendStub = sinon.stub();


### PR DESCRIPTION
Seems https://github.com/microsoft/vscode-python-debugger/pull/620 forgot to update this and so the test wasn't checking if `VSCODE_DEBUGPY_ADAPTER_ENDPOINTS` was being set correctly.
