### PR TITLE
clean Microbuild plugins temp dir

### DIFF
--- a/build/templates/sign.yml
+++ b/build/templates/sign.yml
@@ -82,6 +82,19 @@ steps:
       command: ci
       workingDir: '$(Build.SourcesDirectory)'
 
+  # Workaround for intermittent MicroBuild plugin install collisions
+  # (e.g. "An item with the specified name ...\\MicroBuild\\Plugins\\Az.Accounts already exists")
+  - powershell: |
+      $pluginsRoot = "$(Agent.TempDirectory)/MicroBuild/Plugins"
+      $azAccountsDir = Join-Path $pluginsRoot "Az.Accounts"
+
+      Write-Host "MicroBuild plugins root: $pluginsRoot"
+      if (Test-Path $azAccountsDir) {
+        Write-Host "Removing existing MicroBuild plugin directory: $azAccountsDir"
+        Remove-Item -LiteralPath $azAccountsDir -Recurse -Force -ErrorAction SilentlyContinue
+      }
+    displayName: '🧹 Clean MicroBuild Az.Accounts plugin cache'
+
   # ✅ Enable MicroBuildSigningPlugin for PME enforcement (once for all platforms)
   - task: MicroBuildSigningPlugin@4
     displayName: Enable MicroBuild Signing


### PR DESCRIPTION
error related to temp directory already having nuget package.
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=13112627&view=logs&j=93f03523-1049-5c6a-8fd4-35b2415e4c85&t=1ee9b307-1364-5742-0d3a-ffb4450ed12c


now passing
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=13116504&view=results