### PR TITLE
Try to get around .npmrc not being overridden

### DIFF
--- a/build/templates/publish-extension.yml
+++ b/build/templates/publish-extension.yml
@@ -165,10 +165,6 @@ jobs:
           type: releaseJob # This makes a job a release job
           isProduction: true # Indicates a production release
         steps:
-          - template: setup.yml
-            parameters:
-              installNode: true
-              installPython: false
 
           - task: 1ES.DownloadPipelineArtifact@1
             inputs:

--- a/build/templates/publish.yml
+++ b/build/templates/publish.yml
@@ -102,12 +102,12 @@ steps:
 
             if ('${{ parameters.preRelease }}' -eq 'True') {
               Write-Host 'Publishing as pre-release'
-              Write-Host "Executing: npx vsce publish --pat *** --packagePath $vsixPath --manifestPath $manifestPath --signaturePath $signaturePath --pre-release"
-              npx vsce publish --pat $aadToken --packagePath $vsixPath --manifestPath $manifestPath --signaturePath $signaturePath --pre-release
+              Write-Host "Executing: npx @vscode/vsce@latest publish --pat *** --packagePath $vsixPath --manifestPath $manifestPath --signaturePath $signaturePath --pre-release"
+              npx @vscode/vsce@latest publish --pat $aadToken --packagePath $vsixPath --manifestPath $manifestPath --signaturePath $signaturePath --pre-release
             } else {
               Write-Host 'Publishing as stable release'
-              Write-Host "Executing: npx vsce publish --pat *** --packagePath $vsixPath --manifestPath $manifestPath --signaturePath $signaturePath"
-              npx vsce publish --pat $aadToken --packagePath $vsixPath --manifestPath $manifestPath --signaturePath $signaturePath
+              Write-Host "Executing: npx @vscode/vsce@latest publish --pat *** --packagePath $vsixPath --manifestPath $manifestPath --signaturePath $signaturePath"
+              npx @vscode/vsce@latest publish --pat $aadToken --packagePath $vsixPath --manifestPath $manifestPath --signaturePath $signaturePath
             }
 
             if ($LASTEXITCODE -ne 0) {

--- a/build/templates/setup.yml
+++ b/build/templates/setup.yml
@@ -9,20 +9,6 @@ parameters:
 
 steps:
   - ${{ if eq(parameters.installNode, true) }}:
-      - pwsh: |
-          if (-not (Test-Path '.npmrc')) {
-            Write-Host 'No .npmrc found, creating one with public npm registry'
-            @"
-          # Force public npm registry to avoid CI auth (E401) when no token is provided
-          registry=https://registry.npmjs.org/
-          # Do not require auth for public installs
-          always-auth=false
-          "@ | Out-File -FilePath '.npmrc' -Encoding utf8
-          } else {
-            Write-Host '.npmrc already exists'
-          }
-        displayName: Ensure .npmrc exists
-
       - task: npmAuthenticate@0
         inputs:
           workingFile: .npmrc


### PR DESCRIPTION
- releaseJobs can't checkout source code, but then i couldn't download a .npmrc file so I generated one assuming the npmAuthenticate task would point it to our central feed.  That step happens earlier in an injected task.
- just trying to download vsce and seeing what happens.