### PR TITLE
Removed all --allow-proposed-apis logic (and the EnabledApiProposalsJ…

### DIFF
--- a/build/templates/publish.yml
+++ b/build/templates/publish.yml
@@ -71,8 +71,6 @@ steps:
   - ${{ each platform in parameters.buildPlatforms }}:
       - task: PowerShell@2
         displayName: "Publish extension (${{ coalesce(platform.vsceTarget, 'universal') }})"
-        env:
-          EnabledApiProposalsJson: ${{ parameters.enabledApiProposalsJson }}
         inputs:
           targetType: inline
           script: |
@@ -105,51 +103,16 @@ steps:
             Write-Host "Listing platform folder contents:"
             Get-ChildItem $root | Select-Object Name,Length | Format-Table -AutoSize
 
-            # If the extension uses proposed APIs, vsce requires explicitly allowing them.
-            # We expect EnabledApiProposalsJson to be set by an earlier step (e.g. publish-extension.yml).
-            $allowProposedApisArgs = @()
-            $enabledApiProposalsJson = $env:EnabledApiProposalsJson
-            if ([string]::IsNullOrWhiteSpace($enabledApiProposalsJson)) {
-              Write-Host "EnabledApiProposalsJson is not set; publishing without --allow-proposed-apis."
-            } else {
-              try {
-                $parsedEnabledApiProposals = ConvertFrom-Json -InputObject $enabledApiProposalsJson
-                $enabledApiProposals = @()
-
-                if ($null -ne $parsedEnabledApiProposals) {
-                  foreach ($proposal in @($parsedEnabledApiProposals)) {
-                    if (-not [string]::IsNullOrWhiteSpace([string]$proposal)) {
-                      $enabledApiProposals += [string]$proposal
-                    }
-                  }
-                }
-
-                if ($enabledApiProposals.Count -gt 0) {
-                  Write-Host ("enabledApiProposals (from EnabledApiProposalsJson): " + ($enabledApiProposals -join ', '))
-                  $allowProposedApisArgs = @('--allow-proposed-apis') + $enabledApiProposals
-                } else {
-                  Write-Host "EnabledApiProposalsJson parsed as empty; no proposed API allowlist flags needed."
-                }
-              } catch {
-                Write-Host "EnabledApiProposalsJson was set but could not be parsed; publishing without --allow-proposed-apis."
-              }
-            }
-
-            $allowProposedApisDisplay = ($allowProposedApisArgs -join ' ')
-
             if ('${{ parameters.preRelease }}' -eq 'True') {
               Write-Host 'Publishing as pre-release'
-              $displayCmd = "Executing: npx @vscode/vsce@latest publish --pat *** --packagePath $vsixPath --manifestPath $manifestPath --signaturePath $signaturePath"
-              if ($allowProposedApisDisplay) { $displayCmd += " $allowProposedApisDisplay" }
-              $displayCmd += ' --pre-release'
+              $displayCmd = "Executing: npx @vscode/vsce@latest publish --pat *** --packagePath $vsixPath --manifestPath $manifestPath --signaturePath $signaturePath --no-verify --pre-release"
               Write-Host $displayCmd
-              npx @vscode/vsce@latest publish --pat $aadToken --packagePath $vsixPath --manifestPath $manifestPath --signaturePath $signaturePath $allowProposedApisArgs --pre-release
+              npx @vscode/vsce@latest publish --pat $aadToken --packagePath $vsixPath --manifestPath $manifestPath --signaturePath $signaturePath --no-verify --pre-release
             } else {
               Write-Host 'Publishing as stable release'
-              $displayCmd = "Executing: npx @vscode/vsce@latest publish --pat *** --packagePath $vsixPath --manifestPath $manifestPath --signaturePath $signaturePath"
-              if ($allowProposedApisDisplay) { $displayCmd += " $allowProposedApisDisplay" }
+              $displayCmd = "Executing: npx @vscode/vsce@latest publish --pat *** --packagePath $vsixPath --manifestPath $manifestPath --signaturePath $signaturePath --no-verify"
               Write-Host $displayCmd
-              npx @vscode/vsce@latest publish --pat $aadToken --packagePath $vsixPath --manifestPath $manifestPath --signaturePath $signaturePath $allowProposedApisArgs
+              npx @vscode/vsce@latest publish --pat $aadToken --packagePath $vsixPath --manifestPath $manifestPath --signaturePath $signaturePath --no-verify
             }
 
             if ($LASTEXITCODE -ne 0) {


### PR DESCRIPTION
…son env wiring) from publish.yml.

Updated both publish paths to use --no-verify (correct flag name; --noVerify won’t work): Pre-release: adds --no-verify --pre-release
Stable: adds --no-verify
This should avoid the unknown option '--allow-proposed-apis …' failure entirely by no longer passing that option.