### PR TITLE
fix: use `run.executable` for interpreter identification instead of `activatedRun.executable`

### DIFF
--- a/src/extension/common/python.ts
+++ b/src/extension/common/python.ts
@@ -133,7 +133,7 @@ export async function getSettingsPythonPath(resource?: Uri): Promise<string[] | 
             return undefined;
         }
 
-        const runConfig = execInfo.activatedRun ?? execInfo.run;
+        const runConfig = execInfo.run;
         traceLog(
             `getSettingsPythonPath: Using executable='${runConfig.executable}' args='${
                 runConfig.args?.join(' ') || ''
@@ -255,9 +255,7 @@ export async function getInterpreterDetails(resource?: Uri): Promise<IInterprete
         const env: PythonEnvironment | undefined = await api.getEnvironment(resource);
         // resolve the environment to get full details
         const resolvedEnv = env ? await api.resolveEnvironment(env?.environmentPath) : undefined;
-        const executablePath = resolvedEnv?.execInfo.activatedRun?.executable
-            ? resolvedEnv.execInfo.activatedRun.executable
-            : resolvedEnv?.execInfo.run.executable;
+        const executablePath = resolvedEnv?.execInfo.run.executable;
 
         const a: IInterpreterDetails = {
             path: executablePath ? [executablePath] : undefined,

--- a/src/extension/debugger/adapter/factory.ts
+++ b/src/extension/debugger/adapter/factory.ts
@@ -193,7 +193,7 @@ export class DebugAdapterDescriptorFactory implements IDebugAdapterDescriptorFac
      */
     private async getExecutableCommand(interpreter: PythonEnvironment | undefined): Promise<string[]> {
         if (interpreter) {
-            const executablePath = interpreter.execInfo.activatedRun?.executable ?? interpreter.execInfo.run.executable;
+            const executablePath = interpreter.execInfo.run.executable;
             const version = interpreter.version;
 
             // Parse version string (e.g., "3.8.10" -> major: 3, minor: 8)


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-python-environments/issues/987

Hi @eleanorjboyd. I saw you merged test discovery 2.0 and was very excited to test it. I still have environment activation issues after that PR was merged, so I decided to investigate it a bit further. I'd appreciate it if you could review this PR.

The debugger reads `activatedRun.executable` in three places to figure out which Python binary to use. This works today because every environment manager happens to set `activatedRun.executable` to the actual Python path, but it breaks when a manager sets it to a wrapper command (like `pixi run ... python` or how conda used to do `conda run ... python` before https://github.com/microsoft/vscode-python-environments/pull/860).

I believe the three call sites (`getInterpreterDetails`, `getSettingsPythonPath`, `getExecutableCommand`) aren't running Python, they're identifying the interpreter for things like `resolveEnvironment()` and spawning the debug adapter. And I think that's what `run.executable` is for. `activatedRun` is for execution contexts like `runInBackground` in vscode-python-environments.

The change should be backwards compatible since `run.executable` and `activatedRun.executable` are currently the same value for all existing managers (venv, system, conda). It only matters when they differ, which is the case for pixi-code (see microsoft/vscode-python-environments#987 and https://github.com/microsoft/vscode-python-debugger/issues/872).

Debuggee activation is not affected, that still goes through `getActivatedEnvironmentVariables()` and terminal `envVarCollection`.

This unblocks environment managers from setting `activatedRun` to a wrapper command like `pixi run ... python`, which is needed to fix pytest discovery not activating the environment (microsoft/vscode-python-environments#987). Right now `runInBackground` (used by test discovery) relies on `activatedRun` for execution, but managers can't set it to anything other than the bare Python path without breaking the debugger.