### PR TITLE
feat: add tests and helper for using run.executable for interpreter not activatedRun

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,5 @@
+# Copilot Instructions for vscode-python-debugger
+
+## Learnings
+
+-   Always use `run.executable` (the actual Python binary path) instead of `activatedRun.executable` for interpreter identification in `getInterpreterDetails`, `getSettingsPythonPath`, and `getExecutableCommand`. `activatedRun.executable` may be a wrapper command (e.g. `pixi run python`) set by environment managers like pixi or conda, which breaks the debugger if used as a replacement for the binary. (1)

--- a/src/test/unittest/common/helpers.ts
+++ b/src/test/unittest/common/helpers.ts
@@ -28,3 +28,45 @@ export function buildPythonEnvironment(execPath: string, version: string, sysPre
         sysPrefix,
     } as PythonEnvironment;
 }
+
+/**
+ * Helper to build a PythonEnvironment where activatedRun differs from run.
+ * This simulates environment managers like pixi or conda that set activatedRun
+ * to a wrapper command (e.g. 'pixi run python') while run.executable points to
+ * the actual Python binary.
+ *
+ * @param execPath string - path to the actual python executable (run.executable)
+ * @param activatedRunExecutable string - path/command for the wrapper (activatedRun.executable)
+ * @param version string - python version string (e.g. '3.9.0')
+ * @param activatedRunArgs string[] - optional args for activatedRun
+ */
+export function buildPythonEnvironmentWithActivatedRun(
+    execPath: string,
+    activatedRunExecutable: string,
+    version: string,
+    activatedRunArgs: string[] = [],
+): PythonEnvironment {
+    const execUri = Uri.file(execPath);
+    return {
+        envId: {
+            id: execUri.fsPath,
+            managerId: 'Venv',
+        },
+        name: `Python ${version}`,
+        displayName: `Python ${version}`,
+        displayPath: execUri.fsPath,
+        version: version,
+        environmentPath: execUri,
+        execInfo: {
+            run: {
+                executable: execUri.fsPath,
+                args: [],
+            },
+            activatedRun: {
+                executable: activatedRunExecutable,
+                args: activatedRunArgs,
+            },
+        },
+        sysPrefix: '',
+    } as PythonEnvironment;
+}


### PR DESCRIPTION
follow up to: https://github.com/microsoft/vscode-python-debugger/commit/9fc2797dc42b85ba3fb1bc42dde2729bf81f7f15 adds tests and copilot instructions