### PR TITLE
`package.json` - list missing `code` property

### DIFF
--- a/package.json
+++ b/package.json
@@ -523,6 +523,11 @@
                                 "description": "Absolute path to the program.",
                                 "type": "string"
                             },
+                            "code": {
+                                "default": "",
+                                "description": "Python code to execute in string form.\nExample: \"import debugpy; print(debugpy.__version__)\"",
+                                "type": "string"
+                            },
                             "purpose": {
                                 "default": [],
                                 "description": "Tells extension to use this configuration for test debugging, or when using debug-in-terminal command.",

--- a/src/extension/types.ts
+++ b/src/extension/types.ts
@@ -91,8 +91,8 @@ interface IKnownLaunchRequestArguments extends ICommonDebugArguments {
     sudo?: boolean;
     pyramid?: boolean;
     workspaceFolder?: string;
-    // An absolute path to the program to debug.
     module?: string;
+    // An absolute path to the program to debug.
     program?: string;
     python?: string;
     // Automatically stop target after launch. If not specified, target does not stop.

--- a/src/extension/types.ts
+++ b/src/extension/types.ts
@@ -94,6 +94,7 @@ interface IKnownLaunchRequestArguments extends ICommonDebugArguments {
     module?: string;
     // An absolute path to the program to debug.
     program?: string;
+    code?: string;
     python?: string;
     // Automatically stop target after launch. If not specified, target does not stop.
     stopOnEntry?: boolean;


### PR DESCRIPTION
Hi! Noticed warning when using `code` property in `launch.json`, listed `code` in `package.json` to resolve it.

Used description from https://github.com/microsoft/debugpy/wiki/Debug-configuration-settings

Before (property is not detected and VS Code warns about unallowed property):
<img width="584" height="389" alt="Code_-_Insiders_s0PLMxE4Tc" src="https://github.com/user-attachments/assets/690205a9-fcb6-48ce-866f-7c1a0822fe73" />

After (property is detected and tooltip is shown):
<img width="1001" height="202" alt="Code_-_Insiders_WagmrmL5T4" src="https://github.com/user-attachments/assets/2e7057f6-b6e4-4b94-8c45-da5939fefc05" />
