### PR TITLE
Fix line endings in stable pipeline YAML

### DIFF
--- a/build/azure-devdiv-pipeline.stable.yml
+++ b/build/azure-devdiv-pipeline.stable.yml
@@ -110,6 +110,7 @@ extends:
               isPreRelease: false
               standardizedVersioning: true
               customNPMRegistry: $(AZURE_ARTIFACTS_FEED)
+
       - stage: WaitForValidation
         displayName: Wait for Validation
         dependsOn: Build


### PR DESCRIPTION
Normalizes line endings to CRLF and adds blank line separators between stages. The previous merge introduced LF line endings.