### PR TITLE
envFile parser: support slash-delimited key names (Consul-style variables)

### DIFF
--- a/src/extension/common/variables/environment.ts
+++ b/src/extension/common/variables/environment.ts
@@ -177,7 +177,7 @@ function parseEnvLine(line: string): [string, string] {
     // We don't use dotenv here because it loses ordering, which is
     // significant for substitution.
     // Modified to handle multiline values by using 's' flag so $ matches before newlines in multiline strings
-    const match = line.match(/^\s*(_*[a-zA-Z]\w*)\s*=\s*(.*?)?\s*$/s);
+    const match = line.match(/^\s*(_*[a-zA-Z][\w/]*)\s*=\s*(.*?)?\s*$/s);
     if (!match) {
         return ['', ''];
     }

--- a/src/test/unittest/common/environment.unit.test.ts
+++ b/src/test/unittest/common/environment.unit.test.ts
@@ -102,4 +102,21 @@ suite('Environment File Parsing Tests', () => {
         expect(result.VAR1).to.equal('value1');
         expect(result.VAR2).to.equal('multiline\nvalue');
     });
+
+    test('Should parse keys containing forward slashes (e.g. Consul-style namespaced variables)', () => {
+        const content = 'routes/my_service=http://localhost:8080\nservices/db/host=localhost';
+        const result = parseEnvFile(content);
+
+        expect(result['routes/my_service']).to.equal('http://localhost:8080');
+        expect(result['services/db/host']).to.equal('localhost');
+    });
+
+    test('Should parse mixed standard and slash-namespaced keys in the same file', () => {
+        const content = 'STANDARD_VAR=value1\nroutes/my_service=http://localhost:8080\nANOTHER_VAR=value2';
+        const result = parseEnvFile(content);
+
+        expect(result['STANDARD_VAR']).to.equal('value1');
+        expect(result['routes/my_service']).to.equal('http://localhost:8080');
+        expect(result['ANOTHER_VAR']).to.equal('value2');
+    });
 });


### PR DESCRIPTION
### Problem

`parseEnvLine` uses `/^\s*(_*[a-zA-Z]\w*)\s*=\s*(.*?)?\s*$/` to match env var names. `\w` only allows `[A-Za-z0-9_]`, so keys containing `/` (e.g. `globals/my_storage_dir=/some/path`) are silently dropped — the line matches nothing and is discarded without error.

This affects users whose services use slash-namespaced config keys, a common pattern with Consul (used widely in enterprise deployments). The variables appear in the envFile but are silently ignored, when overriding Consul variables for local development this is extremely difficult to diagnose.

### Fix

Change the key character class from `\w*` to `[\w/]*` to allow `/` in key names.

### Notes

- The `env` dict in launch.json configs already supports these keys without restriction so this aligns `envFile` behaviour with it
- No change to value parsing
