### PR TITLE
Fix debugger launch failure with spaces in interpreter path (regression from #964)

### DIFF
--- a/src/extension/debugger/adapter/factory.ts
+++ b/src/extension/debugger/adapter/factory.ts
@@ -22,7 +22,6 @@ import { sendTelemetryEvent } from '../../telemetry';
 import { Commands, EXTENSION_ROOT_DIR } from '../../common/constants';
 import { Common, DebugConfigStrings, Interpreters } from '../../common/utils/localize';
 import { IPersistentStateFactory } from '../../common/types';
-import { fileToCommandArgumentForPythonExt } from '../../common/stringUtils';
 import { PythonEnvironment } from '../../envExtApi';
 import { resolveEnvironment, getInterpreterDetails, runPythonExtensionCommand } from '../../common/python';
 
@@ -79,13 +78,12 @@ export class DebugAdapterDescriptorFactory implements IDebugAdapterDescriptorFac
             }
 
             let executable = command.shift() ?? 'python';
-
-            // Always ensure interpreter/command is quoted if necessary. Previously this was
-            // only done in the debugAdapterPath branch which meant that in the common case
-            // (using the built‑in adapter path) an interpreter path containing spaces would
-            // be passed unquoted, resulting in a fork/spawn failure on Windows. See bug
-            // report for details.
-            executable = fileToCommandArgumentForPythonExt(executable);
+            // DO NOT apply shell-style quoting here.
+            // The 'executable' path is passed to 'DebugAdapterExecutable', which internally
+            // uses 'child_process.spawn' in a non-shell environment.
+            // Manual quoting will cause the OS (especially Windows) to treat the quotes
+            // as part of the filename, leading to ENOENT.
+            // See regression reported in #1013 and analysis of #964.
 
             // "logToFile" is not handled directly by the adapter - instead, we need to pass
             // the corresponding CLI switch when spawning it.

--- a/src/test/unittest/adapter/factory.unit.test.ts
+++ b/src/test/unittest/adapter/factory.unit.test.ts
@@ -304,28 +304,24 @@ suite('Debugging - Adapter Factory', () => {
 
         assert.deepStrictEqual(descriptor, debugExecutable);
     });
-    test('Add quotes to interpreter path with spaces (default adapter path)', async () => {
+    test('Should not add quotes to interpreter path with spaces (default adapter path)', async () => {
         const session = createSession({});
         const interpreterPathSpaces = 'path/to/python interpreter with spaces';
-        const interpreterPathSpacesQuoted = `"${interpreterPathSpaces}"`;
-        const debugExecutable = new DebugAdapterExecutable(interpreterPathSpacesQuoted, [debugAdapterPath]);
-
+        const debugExecutable = new DebugAdapterExecutable(interpreterPathSpaces, [debugAdapterPath]);
         getInterpreterDetailsStub.resolves({ path: [interpreterPathSpaces] });
         const interpreterSpacePath: PythonEnvironment = createInterpreter(interpreterPathSpaces, '3.7.4-test');
         // Add architecture for completeness.
         (interpreterSpacePath as any).architecture = Architecture.Unknown;
         resolveEnvironmentStub.withArgs(interpreterPathSpaces).resolves(interpreterSpacePath);
         const descriptor = await factory.createDebugAdapterDescriptor(session, nodeExecutable);
-
         assert.deepStrictEqual(descriptor, debugExecutable);
     });
 
-    test('Add quotes to interpreter path with spaces when debugAdapterPath is specified', async () => {
+    test('Should not add quotes to interpreter path with spaces when debugAdapterPath is specified', async () => {
         const customAdapterPath = 'custom/debug/adapter/customAdapterPath';
         const session = createSession({ debugAdapterPath: customAdapterPath });
         const interpreterPathSpaces = 'path/to/python interpreter with spaces';
-        const interpreterPathSpacesQuoted = `"${interpreterPathSpaces}"`;
-        const debugExecutable = new DebugAdapterExecutable(interpreterPathSpacesQuoted, [customAdapterPath]);
+        const debugExecutable = new DebugAdapterExecutable(interpreterPathSpaces, [customAdapterPath]);
 
         getInterpreterDetailsStub.resolves({ path: [interpreterPathSpaces] });
         const interpreterSpacePath: PythonEnvironment = createInterpreter(interpreterPathSpaces, '3.7.4-test');


### PR DESCRIPTION
### Problem
The debugger fails to start (ENOENT error) when the Python interpreter path contains spaces, such as `C:\Program Files\Python312\python.exe`. This is a regression introduced in version 2026.4.0.

### Root Cause
PR #964 unconditionally applied shell-style quoting via `fileToCommandArgumentForPythonExt()` to wrap the interpreter executable path before passing it to `DebugAdapterExecutable`. 

However, `DebugAdapterExecutable` internally uses `child_process.spawn()` in a **non-shell environment**. In this mode:
- Literal quote characters are treated as **part of the filename** rather than delimiters
- This causes the OS to look for a file literally named `"C:\...\python.exe"` (including the quotes)
- Result: `ENOENT: file not found`

### Solution
Remove the shell-style quoting step for the executable path. `child_process.spawn()` correctly handles spaces in paths via array-based argument passing and does not require manual quoting.

### Changes
1. **factory.ts**: Remove `fileToCommandArgumentForPythonExt(executable)` call and replace with explanatory comment
2. **factory.unit.test.ts**: Update two test cases to expect unquoted paths instead of quoted paths

### Testing
- Both "interpreter path with spaces" test cases now verify that paths are passed **without** quotes
- The tests cover both default adapter path and custom debugAdapterPath scenarios

### Related Issues
- Fixes #1013
- Regression from #964