### PR TITLE
Bump version to 2026.7.0-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "debugpy",
     "displayName": "Python Debugger",
     "description": "Python Debugger extension using debugpy.",
-    "version": "2026.6.0",
+    "version": "2026.7.0-dev",
     "publisher": "ms-python",
     "enabledApiProposals": [
         "portsAttributes",


### PR DESCRIPTION
Advance main to the next odd minor pre-release development version.