### PR TITLE
Load native windows-process-tree via appRoot (Follow-up to #991)

### DIFF
--- a/src/extension/debugger/attachQuickPick/provider.ts
+++ b/src/extension/debugger/attachQuickPick/provider.ts
@@ -3,7 +3,8 @@
 
 'use strict';
 
-import { l10n } from 'vscode';
+import * as path from 'path';
+import { env, l10n } from 'vscode';
 import type { IProcessInfo } from '@vscode/windows-process-tree';
 import { getOSType, OSType } from '../../common/platform';
 import { PsProcessParser } from './psProcessParser';
@@ -15,6 +16,14 @@ import { logProcess } from '../../common/process/logger';
 
 export class AttachProcessProvider implements IAttachProcessProvider {
     constructor() {}
+
+    public _loadWindowsProcessTree(): typeof import('@vscode/windows-process-tree') {
+        const wpcPath = path.join(env.appRoot, 'node_modules', '@vscode', 'windows-process-tree');
+        // Use eval to bypass webpack's require interception for loading native addon at runtime
+        // eslint-disable-next-line no-eval
+        const nodeRequire = eval('require') as NodeJS.Require;
+        return nodeRequire(wpcPath);
+    }
 
     public getAttachItems(): Promise<IAttachItem[]> {
         return this._getInternalProcessEntries().then((processEntries) => {
@@ -63,7 +72,7 @@ export class AttachProcessProvider implements IAttachProcessProvider {
 
         if (osType === OSType.Windows) {
             try {
-                const wpc = require('@vscode/windows-process-tree');
+                const wpc = this._loadWindowsProcessTree();
                 const processList = await new Promise<IProcessInfo[]>((resolve) => {
                     wpc.getAllProcesses(
                         (processes: IProcessInfo[]) => resolve(processes),

--- a/src/test/unittest/attachQuickPick/provider.unit.test.ts
+++ b/src/test/unittest/attachQuickPick/provider.unit.test.ts
@@ -13,7 +13,6 @@ import { IAttachItem } from '../../../extension/debugger/attachQuickPick/types';
 import { WmicProcessParser } from '../../../extension/debugger/attachQuickPick/wmicProcessParser';
 import * as platform from '../../../extension/common/platform';
 import * as rawProcessApis from '../../../extension/common/process/rawProcessApis';
-import * as wpc from '@vscode/windows-process-tree';
 
 use(chaiAsPromised);
 
@@ -27,7 +26,12 @@ suite('Attach to process - process provider', () => {
         provider = new AttachProcessProvider();
         getOSTypeStub = sinon.stub(platform, 'getOSType');
         plainExecStub = sinon.stub(rawProcessApis, 'plainExec');
-        getAllProcessesStub = sinon.stub(wpc, 'getAllProcesses');
+        getAllProcessesStub = sinon.stub();
+        sinon.stub(provider, '_loadWindowsProcessTree').returns({
+            getAllProcesses: getAllProcessesStub,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            ProcessDataFlag: { None: 0, Memory: 1, CommandLine: 2 },
+        } as any);
     });
 
     teardown(() => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,7 +38,7 @@ const extensionConfig = {
     '@opentelemetry/instrumentation': 'commonjs @opentelemetry/instrumentation', // ignored because we don't ship instrumentation
     '@azure/opentelemetry-instrumentation-azure-sdk': 'commonjs @azure/opentelemetry-instrumentation-azure-sdk', // ignored because we don't ship instrumentation
     '@azure/functions-core': '@azure/functions-core', // ignored because we don't ship instrumentation
-    '@vscode/windows-process-tree': 'commonjs @vscode/windows-process-tree', // native addon (.node binary); webpack cannot bundle it, resolved at runtime via VS Code's built-in copy
+    '@vscode/windows-process-tree': 'commonjs @vscode/windows-process-tree', // native addon (.node binary); webpack cannot bundle it. Loaded at runtime via vscode.env.appRoot absolute path using eval('require') to bypass webpack's require interception
   },
   resolve: {
     // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader


### PR DESCRIPTION
This is a follow-up to PR #991.
## 🎯 Summary
Fixes an issue where the `@vscode/windows-process-tree` native module failed to load in production. This PR leverages `vscode.env.appRoot` to locate VS Code's built-in module and uses an `eval('require')` bypass to circumvent Webpack’s dependency interception.

## 🔍 Why the previous `require()` approach failed
In published builds, `require('@vscode/windows-process-tree')` consistently threw `MODULE_NOT_FOUND`, causing a silent fallback to WMIC. This was caused by two overlapping technical constraints:

1.  **Module Resolution Boundaries**:
    Since the package is marked as an `external` in Webpack and excluded from the bundle via `.vscodeignore`, the installed extension directory contains no `node_modules/@vscode/windows-process-tree`. Node’s standard resolution algorithm does **not** look inside VS Code’s own `resources/app/node_modules` for bare specifiers.
2.  **Webpack Interception**:
    Even if an absolute path is computed via `appRoot`, Webpack rewrites the standard `require()` call to `__webpack_require__`. This internal function is unable to resolve arbitrary absolute filesystem paths outside of the Webpack dependency graph.

As a result, the optimized native code path was never actually exercised in production.

## 💡 New Design
We now load the module using Node’s native loader by bypassing Webpack's static analysis:

```ts
const wpcPath = path.join(env.appRoot, 'node_modules', '@vscode', 'windows-process-tree');
const nodeRequire = eval('require') as NodeJS.Require;
const wpc = nodeRequire(wpcPath);
```
* **Path Resolution**: Uses `env.appRoot` to point directly to the VS Code installation root, where a compatible version of `@vscode/windows-process-tree` is guaranteed to exist.
* **Webpack Bypass**: Using `eval('require')` returns the true Node.js `require` function. Since Webpack does not analyze the contents of `eval`, it leaves the call untouched, allowing runtime resolution of the absolute path.
* **Robustness & Fallbacks**:
    * The entire logic is wrapped in a `try/catch` block. If the requirement fails (due to ABI mismatch, missing binaries, or older VS Code versions), the existing **WMIC fallback** remains functional.
    * Extracted the logic into `_loadWindowsProcessTree()` to allow unit tests to stub the loader without needing a real VS Code environment or `eval` execution.
* **Type Safety**: `import type` is retained for compile-time checks. These are erased during compilation and do not generate any runtime `import` statements.

// This PR description was generated by AI
// No programmers were harmed in the making of this description