### PR TITLE
Add reload-and-repair flow for Python Debugger activation failures

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -1,5 +1,5 @@
 {
-    "debugpy.command.clearCacheAndReload.title": "Clear Cache and Reload Window",
+    "debugpy.command.clearCacheAndReload.title": "Python Debugger: Reload and Repair",
     "debugpy.command.debugInTerminal.title": "Python Debugger: Debug Python File",
     "debugpy.command.debugUsingLaunchConfig.title": "Python Debugger: Debug using launch.json",
     "debugpy.command.reportIssue.title": "Report Issue...",

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -8,7 +8,7 @@ import { registerLogger, traceError } from './common/log/logging';
 import { sendTelemetryEvent } from './telemetry';
 import { EventName } from './telemetry/constants';
 import { IExtensionApi } from './apiTypes';
-import { commands } from 'vscode';
+import { commands, window } from 'vscode';
 import { getDebugpyPackagePath } from './debugger/adapter/remoteLaunchers';
 
 export async function activate(context: IExtensionContext): Promise<IExtensionApi | undefined> {
@@ -27,7 +27,20 @@ export async function activate(context: IExtensionContext): Promise<IExtensionAp
         sendTelemetryEvent(EventName.DEBUG_SUCCESS_ACTIVATION);
         return api;
     } catch (ex) {
-        traceError('sendDebugpySuccessActivationTelemetry() failed.', ex);
-        throw ex; // re-raise
+        traceError('Python Debugger activation failed.', ex);
+        window
+            .showErrorMessage(
+                'Python Debugger failed to activate. Reload and repair the extension to recover.',
+                'Reload and Repair',
+            )
+            .then((selection) => {
+                if (selection === 'Reload and Repair') {
+                    commands.executeCommand(Commands.ClearStorage).then(
+                        undefined,
+                        () => commands.executeCommand('workbench.action.reloadWindow'),
+                    );
+                }
+            });
+        return undefined;
     }
 }


### PR DESCRIPTION
This PR adds a more resilient activation failure flow for the Python Debugger extension.

- Catches activation failures in `src/extension/extension.ts`
- Logs the failure and shows a user-facing error message
- Offers a `Reload and Repair` action that runs the existing clear cache command or reloads the window
- Updates the command title to `Python Debugger: Reload and Repair` in `package.nls.json`

The extension compiles successfully after this change.