### PR TITLE
fix: Change shebang to use env as the interpreter in noConfigScripts

### DIFF
--- a/bundled/scripts/noConfigScripts/debugpy
+++ b/bundled/scripts/noConfigScripts/debugpy
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 # Bash script
 export DEBUGPY_ADAPTER_ENDPOINTS=$VSCODE_DEBUGPY_ADAPTER_ENDPOINTS
 python3 $BUNDLED_DEBUGPY_PATH --listen 0 --wait-for-client $@


### PR DESCRIPTION
fixes #992

# Summary

On Nixos, the directory structure doesn't follow the FHS specification, causing bash to be unavailable at the `/bin/bash` path. This commit improves noConfigScript's compatibility across Operating Systems by modifying its shebang to dynamically locate the bash interpreter using `/usr/bin/env`.