### PR TITLE
Add breakOnSystemExit setting to launch/attach configuration schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,6 +186,37 @@
                                 },
                                 "type": "object"
                             },
+                            "breakOnSystemExit": {
+                                "description": "Controls which SystemExit exit codes cause the debugger to break. Accepts an array of exit codes and/or inclusive ranges. Set to an empty array to never break on SystemExit. When omitted, the debugger uses its default behavior (break on all non-zero exit codes, ignoring successful exits).",
+                                "type": "array",
+                                "items": {
+                                    "oneOf": [
+                                        {
+                                            "type": "integer",
+                                            "description": "A specific SystemExit code to break on."
+                                        },
+                                        {
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "description": "An inclusive range of SystemExit codes to break on.",
+                                            "properties": {
+                                                "from": {
+                                                    "type": "integer",
+                                                    "description": "Lower bound of the range (inclusive)."
+                                                },
+                                                "to": {
+                                                    "type": "integer",
+                                                    "description": "Upper bound of the range (inclusive)."
+                                                }
+                                            },
+                                            "required": [
+                                                "from",
+                                                "to"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
                             "connect": {
                                 "label": "Attach by connecting to debugpy over a socket.",
                                 "properties": {
@@ -404,6 +435,37 @@
                                     }
                                 },
                                 "type": "object"
+                            },
+                            "breakOnSystemExit": {
+                                "description": "Controls which SystemExit exit codes cause the debugger to break. Accepts an array of exit codes and/or inclusive ranges. Set to an empty array to never break on SystemExit. When omitted, the debugger uses its default behavior (break on all non-zero exit codes, ignoring successful exits).",
+                                "type": "array",
+                                "items": {
+                                    "oneOf": [
+                                        {
+                                            "type": "integer",
+                                            "description": "A specific SystemExit code to break on."
+                                        },
+                                        {
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "description": "An inclusive range of SystemExit codes to break on.",
+                                            "properties": {
+                                                "from": {
+                                                    "type": "integer",
+                                                    "description": "Lower bound of the range (inclusive)."
+                                                },
+                                                "to": {
+                                                    "type": "integer",
+                                                    "description": "Upper bound of the range (inclusive)."
+                                                }
+                                            },
+                                            "required": [
+                                                "from",
+                                                "to"
+                                            ]
+                                        }
+                                    ]
+                                }
                             },
                             "console": {
                                 "default": "integratedTerminal",

--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
                                 "type": "object"
                             },
                             "breakOnSystemExit": {
-                                "description": "Controls which SystemExit exit codes cause the debugger to break. Accepts an array of exit codes and/or inclusive ranges. Set to an empty array to never break on SystemExit. When omitted, the debugger uses its default behavior (break on all non-zero exit codes, ignoring successful exits).",
+                                "description": "Controls which SystemExit exit codes cause the debugger to break. Accepts an array of exit codes and/or inclusive ranges. Set to an empty array to never break on SystemExit. When omitted, the debugger's default applies: successful exits (SystemExit(0) and SystemExit(None), plus 3 under Django/Flask) are ignored, and any other code causes a break when uncaught-exception breaking is enabled.",
                                 "type": "array",
                                 "items": {
                                     "oneOf": [
@@ -437,7 +437,7 @@
                                 "type": "object"
                             },
                             "breakOnSystemExit": {
-                                "description": "Controls which SystemExit exit codes cause the debugger to break. Accepts an array of exit codes and/or inclusive ranges. Set to an empty array to never break on SystemExit. When omitted, the debugger uses its default behavior (break on all non-zero exit codes, ignoring successful exits).",
+                                "description": "Controls which SystemExit exit codes cause the debugger to break. Accepts an array of exit codes and/or inclusive ranges. Set to an empty array to never break on SystemExit. When omitted, the debugger's default applies: successful exits (SystemExit(0) and SystemExit(None), plus 3 under Django/Flask) are ignored, and any other code causes a break when uncaught-exception breaking is enabled.",
                                 "type": "array",
                                 "items": {
                                     "oneOf": [

--- a/src/extension/types.ts
+++ b/src/extension/types.ts
@@ -43,6 +43,11 @@ export type PathMapping = {
     remoteRoot: string;
 };
 
+export type SystemExitRange = {
+    from: number;
+    to: number;
+};
+
 type Connection = {
     host?: string;
     port?: number | string;
@@ -69,6 +74,9 @@ interface ICommonDebugArguments {
     // Show return values of functions while stepping.
     showReturnValue?: boolean;
     subProcess?: boolean;
+    // SystemExit codes (and/or inclusive ranges) that cause the debugger to break.
+    // An empty array disables breaking on SystemExit entirely.
+    breakOnSystemExit?: (number | SystemExitRange)[];
     // An absolute path to local directory with source.
     pathMappings?: PathMapping[];
 }


### PR DESCRIPTION
Exposes debugpy's new `breakOnSystemExit` option ([microsoft/debugpy#2017](https://github.com/microsoft/debugpy/pull/2017)) in the extension's `launch.json` / attach configuration schema, as requested in [microsoft/debugpy#1591](https://github.com/microsoft/debugpy/discussions/1591).

## What

- Adds the `breakOnSystemExit` attribute to both the `launch` and `attach` `configurationAttributes` in `package.json` (IntelliSense + validation in `launch.json`).
- Adds the matching `breakOnSystemExit?: (number | SystemExitRange)[]` field and `SystemExitRange` type to `ICommonDebugArguments` in `src/extension/types.ts`.

## Behavior

`breakOnSystemExit` accepts an array of exit codes and/or inclusive `{ "from", "to" }` ranges, controlling which `SystemExit` codes cause the debugger to break:

- `[]` — never break on `SystemExit`
- `[1, 2]` — break only on codes 1 and 2
- `[{ "from": 3, "to": 100 }]` — break on codes 3-100 (inclusive)
- omitted — debugpy's existing default behavior (break on all non-zero exit codes, ignoring successful exits)

The value is passed straight through to debugpy, which parses it; no config-resolver changes are required.

## Testing

- `tsc --noEmit` passes with no errors.
- `package.json` validated as well-formed JSON.